### PR TITLE
qpSWIFT

### DIFF
--- a/src/opensot/OpenSotImpl.cpp
+++ b/src/opensot/OpenSotImpl.cpp
@@ -55,6 +55,10 @@ OpenSoT::solvers::solver_back_ends backend_from_string(std::string back_end_stri
     {
         return OpenSoT::solvers::solver_back_ends::GLPK;
     }
+    else if(back_end_string == "qpSWIFT")
+    {
+        return OpenSoT::solvers::solver_back_ends::qpSWIFT;
+    }
     else
     {
         throw std::runtime_error("Invalid back end '" + back_end_string + "'");


### PR DESCRIPTION
Added the possibility to select qpSWIFT as back-end. There is a strange small bug: when selecting qpSWIFT as back-end, the terminal output is "???" for the qp solver name, but the solver is correctly loaded. This should be considered when merging the branch.